### PR TITLE
add optional SOCKET_SERVER_FILE_MEMAPI macro

### DIFF
--- a/socket_server.c
+++ b/socket_server.c
@@ -1,3 +1,11 @@
+#ifdef SOCKET_SERVER_FILE_MEMAPI
+#	define	STRINIFY_(S)	#S
+#	define	STRINIFY(S)		STRINIFY_(S)
+#	include	STRINIFY(SOCKET_SERVER_FILE_MEMAPI)
+#	undef	STRINIFY
+#	undef	STRINIFY_
+#endif
+
 #include "socket_server.h"
 #include "socket_poll.h"
 

--- a/socket_server.c
+++ b/socket_server.c
@@ -1,9 +1,9 @@
 #ifdef SOCKET_SERVER_FILE_MEMAPI
-#	define	STRINIFY_(S)	#S
-#	define	STRINIFY(S)		STRINIFY_(S)
-#	include	STRINIFY(SOCKET_SERVER_FILE_MEMAPI)
-#	undef	STRINIFY
-#	undef	STRINIFY_
+#   define  STRINIFY_(S)    #S
+#   define  STRINIFY(S)     STRINIFY_(S)
+#   include STRINIFY(SOCKET_SERVER_FILE_MEMAPI)
+#   undef   STRINIFY
+#   undef   STRINIFY_
 #endif
 
 #include "socket_server.h"

--- a/socket_server.h
+++ b/socket_server.h
@@ -4,9 +4,9 @@
 #include <stdint.h>
 
 // custom malloc/free
-//#define	SOCKET_SERVER_FILE_MEMAPI	skynet.h
-//#define	SOCKET_SERVER_MALLOC		skynet_malloc
-//#define	SOCKET_SERVER_FREE			skynet_free
+//#define SOCKET_SERVER_FILE_MEMAPI   skynet.h
+//#define SOCKET_SERVER_MALLOC        skynet_malloc
+//#define SOCKET_SERVER_FREE          skynet_free
 
 #define SOCKET_DATA 0
 #define SOCKET_CLOSE 1

--- a/socket_server.h
+++ b/socket_server.h
@@ -4,8 +4,9 @@
 #include <stdint.h>
 
 // custom malloc/free
-//#define	SOCKET_SERVER_MALLOC	malloc
-//#define	SOCKET_SERVER_FREE		free
+//#define	SOCKET_SERVER_FILE_MEMAPI	skynet.h
+//#define	SOCKET_SERVER_MALLOC		skynet_malloc
+//#define	SOCKET_SERVER_FREE			skynet_free
 
 #define SOCKET_DATA 0
 #define SOCKET_CLOSE 1


### PR DESCRIPTION
hi,
这个宏用来引入自定义内存函数的声明，比如skynet.h。文件名不加引号，这样方便修改makefile，避免引号嵌套问题。
比如在`skynet`中，需要修改`platform.mk`文件（添加`SOCKET_SERVER_FILE_MEMAPI`定义 ）：

`macosx : SKYNET_DEFINES :=-DNOUSE_JEMALLOC -DSOCKET_SERVER_FILE_MEMAPI=skynet.h`
`linux freebsd : SKYNET_DEFINES := -DSOCKET_SERVER_FILE_MEMAPI=skynet.h`

btw: 好像修改引入了复杂性。如果觉得不合适，可以把之前的修改也一并去掉（宏定义部分）。
